### PR TITLE
Add player combat statistics tracker and sample mod

### DIFF
--- a/Dungeoneer/mods/PlayerStatsMod/StatsMod.java
+++ b/Dungeoneer/mods/PlayerStatsMod/StatsMod.java
@@ -1,0 +1,15 @@
+import com.interrupt.dungeoneer.stats.PlayerStats;
+import com.interrupt.dungeoneer.entities.Player;
+
+/**
+ * Example mod demonstrating how to access realtime player statistics.
+ * This file can be compiled alongside {@code delver_jar_decompiled.java}
+ * to build a playable mod.
+ */
+public class StatsMod {
+    public void onSomeEvent(Player player) {
+        // Example usage: print current stats to console.
+        System.out.println(PlayerStats.instance.toString());
+    }
+}
+

--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/Actor.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/Actor.java
@@ -11,6 +11,7 @@ import com.interrupt.dungeoneer.entities.items.Weapon.DamageType;
 import com.interrupt.dungeoneer.entities.triggers.Trigger;
 import com.interrupt.dungeoneer.game.*;
 import com.interrupt.dungeoneer.rpg.Stats;
+import com.interrupt.dungeoneer.stats.PlayerStats;
 import com.interrupt.dungeoneer.statuseffects.ParalyzeEffect;
 import com.interrupt.dungeoneer.statuseffects.PoisonEffect;
 import com.interrupt.dungeoneer.statuseffects.StatusEffect;
@@ -215,8 +216,8 @@ public class Actor extends Entity {
 		// Healing should heal
 		if(damageType == DamageType.HEALING) damage *= -1f;
 
-		// Vampire should heal the instigator
-		if(damageType == DamageType.VAMPIRE && instigator != null) {
+                // Vampire should heal the instigator
+                if(damageType == DamageType.VAMPIRE && instigator != null) {
 			if(instigator instanceof Actor) {
 				Actor inst = (Actor)instigator;
 				if(inst.isAlive()) {
@@ -250,13 +251,23 @@ public class Actor extends Entity {
 			}
 		}
 		
-		hp -= damage;
+                int originalHp = hp;
+                hp -= damage;
 
-		// clamp out on max hp
-		if(hp > getMaxHp()) hp = getMaxHp();
+                // Track statistics for player combat
+                if(instigator instanceof Player) {
+                        boolean killed = originalHp > 0 && hp <= 0;
+                        PlayerStats.instance.recordHit(damageType, Math.max(damage,0), killed);
+                }
+                if(this instanceof Player) {
+                        PlayerStats.instance.recordDamageReceived(Math.max(damage,0));
+                }
 
-		return damage;
-	}
+                // clamp out on max hp
+                if(hp > getMaxHp()) hp = getMaxHp();
+
+                return damage;
+        }
 	
 	public boolean isAlive()
 	{

--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/Player.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/Player.java
@@ -42,6 +42,7 @@ import com.interrupt.dungeoneer.tiles.Tile;
 import com.interrupt.helpers.PlayerHistory;
 import com.interrupt.managers.HUDManager;
 import com.interrupt.managers.StringManager;
+import com.interrupt.dungeoneer.stats.PlayerStats;
 
 import java.text.MessageFormat;
 import java.util.HashMap;
@@ -746,6 +747,8 @@ public class Player extends Actor {
         Array<LerpFrame> deathFrames = new Array<LerpFrame>();
 
         GameManager.getGameMode().onPlayerDeath(this);
+
+        PlayerStats.instance.recordDeath();
 
         floating = false;
 

--- a/Dungeoneer/src/com/interrupt/dungeoneer/stats/PlayerStats.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/stats/PlayerStats.java
@@ -1,0 +1,58 @@
+package com.interrupt.dungeoneer.stats;
+
+import com.interrupt.dungeoneer.entities.items.Weapon.DamageType;
+
+/**
+ * Tracks realtime player combat statistics.
+ */
+public class PlayerStats {
+    private int meleeKills = 0;
+    private int magicKills = 0;
+    private int meleeHits = 0;
+    private int magicHits = 0;
+    private int damageInflicted = 0;
+    private int damageReceived = 0;
+    private int deaths = 0;
+
+    public static final PlayerStats instance = new PlayerStats();
+
+    private PlayerStats() {}
+
+    /** Records a hit dealt by the player. */
+    public void recordHit(DamageType damageType, int damage, boolean killed) {
+        if (damageType == DamageType.PHYSICAL) {
+            meleeHits++;
+            if (killed) meleeKills++;
+        }
+        else {
+            magicHits++;
+            if (killed) magicKills++;
+        }
+        if (damage > 0) damageInflicted += damage;
+    }
+
+    /** Records damage received by the player. */
+    public void recordDamageReceived(int damage) {
+        if (damage > 0) damageReceived += damage;
+    }
+
+    /** Records a player death. */
+    public void recordDeath() {
+        deaths++;
+    }
+
+    public int getMeleeKills() { return meleeKills; }
+    public int getMagicKills() { return magicKills; }
+    public float getMeleeHitsPerKill() { return meleeKills == 0 ? 0f : (float) meleeHits / meleeKills; }
+    public float getMagicHitsPerKill() { return magicKills == 0 ? 0f : (float) magicHits / magicKills; }
+    public float getDamageRatio() { return damageInflicted == 0 ? 0f : (float) damageReceived / damageInflicted; }
+    public int getDeaths() { return deaths; }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "Melee kills: %d, Magic kills: %d, Melee hits/kill: %.2f, Magic hits/kill: %.2f, Damage ratio: %.2f, Deaths: %d",
+                meleeKills, magicKills, getMeleeHitsPerKill(), getMagicHitsPerKill(), getDamageRatio(), deaths);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `PlayerStats` to gather melee/magic kills, hits, damage ratios, and deaths in real time
- hook stats tracker into `Actor.takeDamage` and `Player.die`
- provide example mod `StatsMod` demonstrating how to query stats with `delver_jar_decompiled.java`

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./gradlew test -Dorg.gradle.java.home=/usr/lib/jvm/java-17-openjdk-amd64` *(fails: Could not resolve com.android.tools.build:gradle:3.4.1 due to missing cacerts)*

------
https://chatgpt.com/codex/tasks/task_e_68ad724320e48329a92d6d9d1bea85fa